### PR TITLE
Remove debug logs from BMI calculator

### DIFF
--- a/src/BMI.js
+++ b/src/BMI.js
@@ -1,18 +1,8 @@
 export const getAverageBodyMassIndex = (people) => {
-    try {
-        const totalBodyMassIndex = people.reduce((total, person) => {
-            console.log('person: ', person);
-            const bodyMassIndex = person.weight / (person.height * person.height);
-            console.log('body mass indexx: ', bodyMassIndex);
-            return total + bodyMassIndex;
-        }, 0);
+    const totalBodyMassIndex = people.reduce((total, person) => {
+        const bodyMassIndex = person.weight / (person.height * person.height);
+        return total + bodyMassIndex;
+    }, 0);
 
-        console.log('testing')
-
-        return totalBodyMassIndex / people.length;
-    } catch (error) {
-        console.log('It was not possible to calculate the average body mass index');
-        return error;
-    }
+    return totalBodyMassIndex / people.length;
 }
-


### PR DESCRIPTION
Removed all debug logs from the Body Mass Index calculator,This improves the readability of the code and reduces the amount of unnecessary information in the logs

[This PR and the changes in it were generated by Jira-GPT (wip)]