### PR TITLE
Add alt text to Google Logo

### DIFF
--- a/src/GoogleLogo.jsx
+++ b/src/GoogleLogo.jsx
@@ -4,7 +4,7 @@ const GoogleLogo = () => {
   return (
     <div>
       <h2>Google</h2>
-      <img src="google.jpg"/>
+      <img src="google.jpg" alt="Google logo"/>
     </div>
   );
 };


### PR DESCRIPTION
- Added alt text to Google Logo in GoogleLogo.jsx file
- Alt text describes the logo as 'Google logo'
- Improves accessibility for users who rely on screen readers

[This PR and the changes in it were generated by Jira-GPT (wip)]